### PR TITLE
[Origination/Balance] - Fix origination balance

### DIFF
--- a/src/taquito-wallet.ts
+++ b/src/taquito-wallet.ts
@@ -111,7 +111,12 @@ function assertConnected(perm: ThanosDAppPermission): asserts perm {
 
 function formatOpParams(op: any) {
   const { fee, gas_limit, storage_limit, ...rest } = op;
-  if (op.kind === "transaction") {
+  if (op.kind === "origination") {
+    return {
+      ...rest,
+      mutez: true, // The balance was already converted from Tez (ꜩ) to Mutez (uꜩ)
+    }
+  } else if (op.kind === "transaction") {
     const { destination, amount, parameters, ...txRest } = rest;
     return {
       ...txRest,


### PR DESCRIPTION
Thanos wallet originates contracts after converting the balance from ꜩ to uꜩ twice. It is possible that other wallets also have this issue, but I've not tested them.

PR that facilitates this from **taquito** side.
[taquito/pull/581](https://github.com/ecadlabs/taquito/pull/581)

This fix will only work once PR [thanos-wallet/pull/221](https://github.com/madfish-solutions/thanos-wallet/pull/221) gets merged.
**Depends on the taquito version bump on the wallet extension**