### PR TITLE
[Origination/Balance] - Fix origination balance

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "typescript": "^3.9.6"
   },
   "peerDependencies": {
-    "@taquito/taquito": "^7.0.0 || ^7.0.0-beta"
+    "@taquito/taquito": "^8.0.0 || ^8.0.0-beta.1"
   }
 }

--- a/src/taquito-wallet.ts
+++ b/src/taquito-wallet.ts
@@ -111,15 +111,22 @@ function assertConnected(perm: ThanosDAppPermission): asserts perm {
 
 function formatOpParams(op: any) {
   const { fee, gas_limit, storage_limit, ...rest } = op;
-  if (op.kind === "transaction") {
-    const { destination, amount, parameters, ...txRest } = rest;
-    return {
-      ...txRest,
-      to: destination,
-      amount: +amount,
-      mutez: true,
-      parameter: parameters,
-    };
+  switch (op.kind) {
+    case "origination":
+      return {
+        ...rest,
+        mutez: true, // The balance was already converted from Tez (ꜩ) to Mutez (uꜩ)
+      }
+    case "transaction":
+      const { destination, amount, parameters, ...txRest } = op;
+      return {
+        ...txRest,
+        to: destination,
+        amount: +amount,
+        mutez: true,
+        parameter: parameters,
+      };
+    default:
+      return rest;
   }
-  return rest;
 }


### PR DESCRIPTION
Thanos wallet originates contracts after converting the balance from ꜩ to uꜩ twice. It is possible that other wallets also have this issue, but I've not tested them.

PR that facilitates this from **taquito** side.
[taquito/pull/581](https://github.com/ecadlabs/taquito/pull/581)